### PR TITLE
feat: bgColor

### DIFF
--- a/packages/cli/src/private/bgColor.ts
+++ b/packages/cli/src/private/bgColor.ts
@@ -1,0 +1,16 @@
+function _(number: number) {
+  return (message: string) =>
+    `\x1b[${number}m${message}\x1b[0m`;
+}
+
+export default {
+  black: _(40),
+  blue: _(44),
+  cyan: _(46),
+  gray: _(100),
+  green: _(42),
+  magenta: _(45),
+  red: _(41),
+  white: _(47),
+  yellow: _(43),
+};

--- a/packages/cli/src/public/bgColor.ts
+++ b/packages/cli/src/public/bgColor.ts
@@ -1,0 +1,1 @@
+export { default } from "#bgColor";


### PR DESCRIPTION
# bgColor                                                                                                        
                                                                                                               
  - Add bgColor module to @rcompat/cli mirroring color but using ANSI background codes (40–47, 100)              
  - Follows existing private/public export pattern — no package.json changes needed (wildcard #* / ./* patterns  
  cover it)                                                                                                      
  - Colors: black, red, green, yellow, blue, magenta, cyan, white, gray                                          
  - No bold/dim/inverse — those are text styles, not background colors                                           
                                                                                                                 
To test:

Create a temporary test.ts file in packages/cli/src/test.ts with:

```ts
// packages/cli/test.ts
import print from "./src/private/print"
import color from "./src/private/color"
import bgColor from "./src/private/bgColor"

print("\n")
print(color.black(bgColor.red(" ERROR ")));
print("\n")
print("\n")
print(color.black(bgColor.green(" SUCCESS ")));
print("\n")
print("\n")
```

And run :

```
pnpm install && cd packages/io && pnpm build && cd ../../packages/cli && bun run test.ts
```

Result should be:

<img width="675" height="126" alt="Screenshot 2026-04-21 at 13 31 14" src="https://github.com/user-attachments/assets/43938134-e612-4c3a-ab82-c04364fdb439" />
