### PR TITLE
[Rcompat/test]: base surface and support chaining

### DIFF
--- a/packages/test/README.md
+++ b/packages/test/README.md
@@ -414,6 +414,53 @@ The factory receives the base `assert` function and the current `subject`
 (the value passed to `assert()`). Return an object whose methods will be
 mixed into every `Assert` instance for that test.
 
+The extended test keeps the full base surface — `group`, `mock`, `spy`,
+`import`, and `intercept` all keep working on it, so you can group, mock, and
+intercept exactly as you would on `test` itself.
+
+```js
+import test from "@rcompat/test";
+
+const myTest = test.extend((assert, subject) => ({
+  even() {
+    assert(subject % 2 === 0).true();
+    return this;
+  },
+}));
+
+myTest.group("arithmetic", () => {
+  myTest.case("even numbers", assert => {
+    assert(2).even();
+    assert(4).even();
+  });
+});
+```
+
+An extended test is itself extendable: chain `test.extend(...)` calls to
+compose assertions. Later `extend` calls win on overlapping keys, just as if
+you had merged the factories into a single `test.extend(...)`.
+
+```js
+import test from "@rcompat/test";
+
+const chained = test.extend((assert, subject) => ({
+  even() {
+    assert(subject % 2 === 0).true();
+    return this;
+  },
+})).extend((assert, subject) => ({
+  odd() {
+    assert(subject % 2 === 1).true();
+    return this;
+  },
+}));
+
+chained.case("parity", assert => {
+  assert(2).even();
+  assert(3).odd();
+});
+```
+
 ## API Reference
 
 ### `test.case`
@@ -502,10 +549,12 @@ test.extend<Subject, Extensions>(
 ```
 
 Create a new test object with custom assertion methods mixed into the
-asserter.
+asserter. The returned `ExtendedTest` keeps the full base surface
+(`group`, `mock`, `spy`, `import`, `intercept`) and is itself extendable, so
+`test.extend(...)` calls can be chained to compose assertions.
 
 | Parameter | Type       | Description                                               |
-| --------- | ---------- | --------------------------------------------------------- |
+| --------- | ---------- | -------------------------------------------------------- |
 | `factory` | `function` | Returns extra methods to attach to each `Assert` instance |
 
 ### `test.spy`

--- a/packages/test/src/private/extend.spec.ts
+++ b/packages/test/src/private/extend.spec.ts
@@ -1,0 +1,55 @@
+import test from "#index";
+
+// A simple extension used across the specs.
+const extended = test.extend((assert, subject: number) => ({
+  even() {
+    assert(subject % 2 === 0).true();
+    return this;
+  },
+}));
+
+extended.case("single extend still asserts", assert => {
+  assert(2).even();
+});
+
+extended.group("extended-group", () => {
+  extended.case("group runs on an extended test", assert => {
+    assert(4).even();
+  });
+});
+
+extended.case("extended test forwards spy", assert => {
+  const tracked = extended.spy((a: number, b: number) => a + b);
+
+  assert(tracked.called).false();
+  tracked(1, 2);
+  assert(tracked.called).true();
+  assert(tracked.calls).equals([[1, 2]]);
+});
+
+const chained = test.extend((assert, subject: number) => ({
+  even() {
+    assert(subject % 2 === 0).true();
+    return this;
+  },
+})).extend((assert, subject: number) => ({
+  odd() {
+    assert(subject % 2 === 1).true();
+    return this;
+  },
+}));
+
+chained.case("chained extend exposes both extensions", assert => {
+  assert(2).even();
+  assert(3).odd();
+});
+
+const overlap = test.extend((_assert, _subject: number) => ({
+  marker: "first",
+})).extend((_assert, _subject: number) => ({
+  marker: "second",
+}));
+
+overlap.case("later extend wins on overlapping keys", assert => {
+  assert(assert(0).marker).equals("second");
+});

--- a/packages/test/src/private/extend.ts
+++ b/packages/test/src/private/extend.ts
@@ -2,6 +2,10 @@ import type Assert from "#Assert";
 import type Asserter from "#Asserter";
 import type Body from "#Body";
 import type { MaybePromise } from "@rcompat/type";
+import type import_ from "#import";
+import type intercept from "#intercept";
+import type mock from "#mock";
+import type spy from "#spy";
 
 type ExtendedAssert<T, Extensions> = Assert<T> & Extensions;
 
@@ -14,21 +18,31 @@ type ExtendedBody<Extensions> =
 export type Factory<Subject, Extensions> =
   (assert: Asserter, subject: Subject) => Extensions;
 
-export type ExtendedTest<Extensions> = {
-  case(name: string, body: ExtendedBody<Extensions>): void;
-  ended(end: () => MaybePromise<void>): void;
-};
-
 type Base = {
   case(name: string, body: Body): void;
   ended(end: () => MaybePromise<void>): void;
+  group(name: string, fn: () => void): void;
+  mock: typeof mock;
+  spy: typeof spy;
+  import: typeof import_;
+  intercept: typeof intercept;
 };
 
-export default <Subject, Extensions>(
+type Forwarded = Omit<Base, "case">;
+
+export type ExtendedTest<Extensions> = Forwarded & {
+  case(name: string, body: ExtendedBody<Extensions>): void;
+
+  extend<ForwardedSubject, ForwardedExtensions>(
+    factory: Factory<ForwardedSubject, ForwardedExtensions>,
+  ): ExtendedTest<Extensions & ForwardedExtensions>;
+};
+
+const extend = <Subject, Extensions>(
   base: Base,
   factory: Factory<Subject, Extensions>,
-): ExtendedTest<Extensions> => ({
-  case(name, body) {
+): ExtendedTest<Extensions> => {
+  const extended_case = (name: string, body: ExtendedBody<Extensions>) =>
     base.case(name, asserter => {
       const extended = <T>(actual?: T) => {
         const a = asserter(actual);
@@ -37,6 +51,20 @@ export default <Subject, Extensions>(
       };
       return body(extended as ExtendedAsserter<Extensions>);
     });
-  },
-  ended: base.ended.bind(base),
-});
+
+  return {
+    ...base, // forwards ended, group, mock, spy, import, intercept
+    case: extended_case, // overrides base.case with the wrapping variant
+    extend<ForwardedSubject, ForwardedExtensions>(forwardedFactory: Factory<ForwardedSubject, ForwardedExtensions>) {
+      const combined: Factory<ForwardedSubject | Subject, Extensions & ForwardedExtensions> =
+        (assert, subject) => ({
+          ...factory(assert, subject as Subject),
+          ...forwardedFactory(assert, subject as ForwardedSubject),
+        });
+
+      return extend(base, combined);
+    },
+  };
+};
+
+export default extend;

--- a/packages/test/src/private/index.ts
+++ b/packages/test/src/private/index.ts
@@ -25,11 +25,11 @@ const base = {
   mock,
   spy,
   import: import_,
+  intercept,
 };
 
 export default {
   ...base,
-  intercept,
   extend<Subject, Extensions>(factory: Factory<Subject, Extensions>):
     ExtendedTest<Extensions> {
     return extend(base, factory);


### PR DESCRIPTION
### Problem                                                                                                                                                                                                     
                                                                                                                                                                                                                 
 test.extend had two related gaps:                                                                                                                                                                               
                                                                                                                                                                                                                 
 1. **Extended tests dropped the base surface**. ExtendedTest<Extensions> only declared case and ended, and extend.ts returned an object literal listing only those two. So group, mock, spy, import, and intercept  
    — all present on the base object in index.ts — were lost on an extended test, both at the type level and at runtime.                                                                                         
                                                                                                                                                                                                                 
     - TypeScript: Property 'group' does not exist on type 'ExtendedTest<...>'                                                                                                                                   
     - Runtime (proby): TypeError: ... group is not a function                                                                                                                                                   
                                                                                                                                                                                                                 
 2. **An extended test couldn't be extended again**. ExtendedTest had no extend method, so test.extend(a).extend(b) wasn't possible — you had to manually merge factories into a single test.extend(...) call.       
                                                                                                                                                                                                                 
 ### Root cause                                                                                                                                                                                                  
                                                                                                                                                                                                                 
 Both issues share one cause: extend.ts built its return object by hand, listing only case/ended, so it fell out of sync with whatever base exposes and never exposed extend itself.                             
                                                                                                                                                                                                                 
 ### Fix                                                                                                                                                                                                         
                                                                                                                                                                                                                 
 Forward the entire base surface and only override case, then add extend so the result is itself extendable. This keeps extend.ts in sync with base going forward instead of re-listing each method.             
                                                                                                                                                                                                                 
 packages/test/src/private/extend.ts                                                                                                                                                                             
 - Widened the Base type to the full surface (case, ended, group, mock, spy, import, intercept); mock/spy/import/intercept are type-only imports, so no runtime coupling is added.                               
 - ExtendedTest<Extensions> now exposes the forwarded base surface (Omit<Base, "case">) plus the overriding case (taking ExtendedBody<Extensions>) and a new extend method for chaining.                         
 - Switched the returned object from an explicit { case, ended } literal to { ...base, case: extended_case, extend }, so group/mock/spy/import/intercept/ended forward by reference. None of those methods use `this` (they delegate to the repository singleton or are plain imports), so spreading is safe — no binding needed.                                                                                              
 - Named the function (const extend + export default) so the chained extend can recurse on the original base rather than this. This prevents the case wrapper from stacking across chained calls, keeping the behavior identical whether you extend once or chain several times.                                                                                                                                            
 - The chained extend merges factories (later extend wins on overlapping keys), matching the manual-merge semantics.                                                                                             
                                                                                                                                                                                                                 
 packages/test/src/private/index.ts                                                                                                                                                                              
 - Moved intercept into base so the full surface forwards through extend(...)) (previously intercept sat only on the top-level default export, so an extended test lost it). No behavioral change for direct test usage.
                                                                                                                                                                                                                 
 packages/test/src/private/extend.spec.ts (new — 6 cases)                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                 
 packages/test/README.md                                                                                                                                                                                         
 - Expanded the "Extending the asserter" section to document that the extended test keeps the full base surface and can itself be extended, with group + chaining examples.                                      
 - Updated the test.extend API reference entry.
                                                                                               
 ### Verification                                                                                                                                                                                                
                                                                                                                                                                                                                 
 - pnpm build  — passes
 - npm test (proby) — 60 passed, 0 failed, including the 6 new cases                                                                                                                                             
 - Targeted run of proby src/private/extend.spec.ts and its group filter — both pass                                                                                                                             
 - No new lint errors/warnings introduced by the changed files